### PR TITLE
Allow for Reference fields to cache data they reference.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+line_length=120
+known_first_party=marrow,web,cinje
+multi_line_output=4
+balanced_wrapping=True
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,35 @@
--   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    sha: c8a1c91c762b8e24fdc5a33455ec10662f523328
-    hooks:
-    -   id: check-added-large-files
-    -   id: check-ast
-    -   id: check-byte-order-marker
-    -   id: check-merge-conflict
-    -   id: check-symlinks
-    -   id: debug-statements
-    -   id: detect-private-key
-    -   id: end-of-file-fixer
-    -   id: check-json
-    -   id: check-xml
-    -   id: check-yaml
+- repo: https://github.com/pre-commit/pre-commit-hooks.git
+  sha: c8a1c91c762b8e24fdc5a33455ec10662f523328
+  hooks:
+    - id: check-added-large-files
+    - id: check-ast
+    - id: check-byte-order-marker
+    - id: check-docstring-first
+    - id: check-merge-conflict
+    - id: check-symlinks
+    - id: debug-statements
+    - id: detect-private-key
+    - id: end-of-file-fixer
+    - id: check-json
+    - id: check-xml
+    - id: check-yaml
+- repo: git://github.com/FalconSocial/pre-commit-python-sorter
+  sha: 1.0.1
+  hooks:
+    - id: python-import-sorter
+      args: ['--silent-overwrite']
+- repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+  sha: v1.0.9
+  hooks:
+    - id: python-safety-dependencies-check
+- repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
+  sha: v1.0.1
+  hooks:
+    - id: python-bandit-vulnerability-check
+- repo: local
+  hooks:
+    - id: py.test
+      name: py.test
+      language: system
+      entry: sh -c py.test
+      files: ''

--- a/marrow/mongo/core/field/complex.py
+++ b/marrow/mongo/core/field/complex.py
@@ -153,7 +153,7 @@ class Reference(_HasKinds, Field):
 			except KeyError:
 				raise ValueError("Must reference a document with an _id.")
 		
-		elif isinstance(value, (OID, DBRef)):
+		elif isinstance(value, OID):
 			inst['_id'] = value
 		
 		elif isinstance(value, (str, unicode)) and len(value) == 24:
@@ -167,9 +167,8 @@ class Reference(_HasKinds, Field):
 		
 		for field in self.cache:
 			if __debug__:  # This verification is potentially expensive, so skip it in production.
-				for chunk in field.split('.'):
-					if chunk.isnumeric():
-						raise ValueError("May not contain numeric array references.")
+				if any(chunk.isnumeric() for chunk in field.split('.')):
+					raise ValueError("May not contain numeric array references.")
 			
 			try:
 				nested = traverse(value, field)

--- a/marrow/mongo/core/field/complex.py
+++ b/marrow/mongo/core/field/complex.py
@@ -137,7 +137,7 @@ class Reference(_HasKinds, Field):
 		
 		return 'objectId'
 	
-	def _populate_cache(self, obj, value):
+	def _populate_cache(self, value):
 		inst = odict()
 		
 		if isinstance(value, Document):
@@ -153,7 +153,7 @@ class Reference(_HasKinds, Field):
 			except KeyError:
 				raise ValueError("Must reference a document with an _id.")
 		
-		elif isinstance(value, OID):
+		elif isinstance(value, (OID, DBRef)):
 			inst['_id'] = value
 		
 		elif isinstance(value, (str, unicode)) and len(value) == 24:
@@ -172,7 +172,7 @@ class Reference(_HasKinds, Field):
 						raise ValueError("May not contain numeric array references.")
 			
 			try:
-				nested = traverse(obj, field)
+				nested = traverse(value, field)
 				
 			except LookupError:
 				pass
@@ -192,7 +192,7 @@ class Reference(_HasKinds, Field):
 		"""Transform to a MongoDB-safe value."""
 		
 		if self.cache:
-			return self._populate_cache(obj, value)
+			return self._populate_cache(value)
 		
 		# First, we handle the typcial Document object case.
 		if isinstance(value, Document):

--- a/marrow/mongo/core/field/complex.py
+++ b/marrow/mongo/core/field/complex.py
@@ -123,7 +123,7 @@ class Embed(_HasKinds, _CastingKind, Field):
 
 class Reference(_HasKinds, Field):
 	concrete = Attribute(default=False)  # If truthy, will store a DBRef instead of ObjectId.
-	#cache = Attribute(default=None)  # Attributes to preserve from the referenced object at the reference level.
+	cache = Attribute(default=None)  # Attributes to preserve from the referenced object at the reference level.
 	
 	@property
 	def __foreign__(self):

--- a/marrow/mongo/core/field/complex.py
+++ b/marrow/mongo/core/field/complex.py
@@ -191,7 +191,7 @@ class Reference(_HasKinds, Field):
 		"""Transform to a MongoDB-safe value."""
 		
 		if self.cache:
-			return self._populate_cache(self, value)
+			return self._populate_cache(value)
 		
 		# First, we handle the typcial Document object case.
 		if isinstance(value, Document):

--- a/marrow/mongo/core/field/complex.py
+++ b/marrow/mongo/core/field/complex.py
@@ -171,7 +171,7 @@ class Reference(_HasKinds, Field):
 						raise ValueError("May not contain numeric array references.")
 			
 			try:
-				nested = current[parts[-1]] = traverse(obj, field)
+				nested = traverse(obj, field)
 				
 			except LookupError:
 				pass

--- a/marrow/mongo/core/field/complex.py
+++ b/marrow/mongo/core/field/complex.py
@@ -137,12 +137,13 @@ class Reference(_HasKinds, Field):
 		
 		return 'objectId'
 	
-	def _populate_cache(self, value):
+	def _populate_cache(self, obj, value):
 		inst = odict()
 		
 		if isinstance(value, Document):
 			try:
 				inst['_id'] = value.__data__['_id']
+				inst['_cls'] = canon(value.__class__)
 			except KeyError:
 				raise ValueError("Must reference a document with an _id.")
 		
@@ -191,7 +192,7 @@ class Reference(_HasKinds, Field):
 		"""Transform to a MongoDB-safe value."""
 		
 		if self.cache:
-			return self._populate_cache(value)
+			return self._populate_cache(obj, value)
 		
 		# First, we handle the typcial Document object case.
 		if isinstance(value, Document):

--- a/test/field/test_complex.py
+++ b/test/field/test_complex.py
@@ -224,13 +224,67 @@ class TestCachingReferenceField(FieldExam):
 		assert inst.field['_cls'] == 'test_complex:Concrete'
 		assert inst.field['foo'] == val['foo']
 	
+	def test_foreign_cast_dict(self, Sample):
+		val = {'_id': oid('58329b3a927cc647e94153c9'), 'foo': 'foo', 'bar': 'bar'}
+		
+		inst = Sample(field=val)
+		
+		assert isinstance(inst.field, odict)
+		assert inst.field['_id'] == val['_id']
+		assert '_cls' not in inst.field
+		assert inst.field['foo'] == val['foo']
+	
+	def test_foreign_cast_oid(self, Sample):
+		val = oid('58329b3a927cc647e94153c9')
+		
+		inst = Sample(field=val)
+		
+		assert isinstance(inst.field, odict)
+		assert inst.field['_id'] == val
+		assert '_cls' not in inst.field
+		assert 'foo' not in inst.field
+	
+	def test_foreign_cast_string_oid(self, Sample):
+		val = '58329b3a927cc647e94153c9'
+		
+		inst = Sample(field=val)
+		
+		assert isinstance(inst.field, odict)
+		assert inst.field['_id'] == oid(val)
+		assert '_cls' not in inst.field
+		assert 'foo' not in inst.field
+	
 	def test_foreign_cast_document_fail(self, Sample):
 		with pytest.raises(ValueError):
 			Sample(Concrete())
 	
-	def test_foreign_cast_reference(self, Sample):
-		inst = Sample('58329b3a927cc647e94153c9')
-		assert isinstance(inst.field, odict)
+	def test_foreign_cast_dict_fail(self, Sample):
+		with pytest.raises(ValueError):
+			Sample({})
+	
+	def test_foreign_cast_string_oid_fail(self, Sample):
+		with pytest.raises(ValueError):
+			Sample('58329b3a927cc647e941x3c9')
+	
+	def test_foreign_cast_other_fail(self, Sample):
+		with pytest.raises(ValueError):
+			Sample(object())
+	
+	def test_foreign_cast_numeric_fail(self):
+		class Sample(Document):
+			field = Reference(Concrete, cache=('foo.1', ))
+		
+		with pytest.raises(ValueError):
+			Sample(oid('58329b3a927cc647e94153c9'))
+	
+	def test_foreign_cast_nested(self, Sample):
+		class Ref(Document):
+			field = Reference(Document, cache=('field.field', ))
+		
+		val = {'_id': oid('58329b3a927cc647e94153c9'), 'field': {'field': 27}}
+		inst = Ref(val)
+		
+		assert inst.field['field']['field'] == 27
 
 
 class TestExplicitPluginReferenceField(FieldExam):


### PR DESCRIPTION
This allows speeding up of searches, by allowing for search (and indexing!) of the cached information, saving a fake join.  Additionally, this allows for subsequent display of this information without requiring sub-queries.