### PR TITLE
Allow for fields to be combined, not just query documents.

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,8 +1,4 @@
-doc-warnings: false
-test-warnings: false
-strictness: veryhigh
 max-line-length: 120
-autodetect: true
 ignore-paths:
   - example
 python-stargets:
@@ -11,9 +7,5 @@ python-stargets:
 pylint:
   disable:
     - redefined-builtin
-mccabe:
-  run: true
-dodgy:
-  run: true
 pyroma:
   run: true

--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,7 +1,7 @@
 max-line-length: 120
 ignore-paths:
   - example
-python-stargets:
+python-targets:
   - 2
   - 3
 pylint:

--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,0 +1,19 @@
+doc-warnings: false
+test-warnings: false
+strictness: veryhigh
+max-line-length: 120
+autodetect: true
+ignore-paths:
+  - example
+python-stargets:
+  - 2
+  - 3
+pylint:
+  disable:
+    - redefined-builtin
+mccabe:
+  run: true
+dodgy:
+  run: true
+pyroma:
+  run: true

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 marrow.mongo
 ============
 
-|latestversion| |ghtag| |masterstatus| |mastercover| |masterreq| |ghwatch| |ghstar|
+|latestversion| |ghtag| |masterstatus| |mastercover| |masterhealth| |masterreq| |ghwatch| |ghstar|
 
     © 2016 Alice Bevan-McGregor and contributors.
 
@@ -50,7 +50,7 @@ This package has only one hard dependency, a modern (>3.2) version of the ``pymo
 Development Version
 -------------------
 
-|developstatus| |developcover| |ghsince| |issuecount| |ghfork|
+|developstatus| |developcover| |develophealth| |ghsince| |issuecount| |ghfork|
 
 Development takes place on `GitHub <https://github.com/>`__ in the
 `marrow.mongo <https://github.com/marrow/mongo/>`__ project.  Issue tracking, documentation, and downloads
@@ -280,8 +280,12 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     :target: https://pypi.python.org/pypi/marrow.mongo
     :alt: Latest released version.
 
-.. |downloads| image:: http://img.shields.io/pypi/dw/marrow.mongo.svg?style=flat
-    :target: https://pypi.python.org/pypi/marrow.mongo
-    :alt: Downloads per week.
+.. |masterhealth| image:: https://landscape.io/github/marrow/mongo/master/landscape.svg?style=flat
+    :target: https://landscape.io/github/marrow/mongo/master
+    :alt: Master Branch Code Health
+
+.. |develophealth| image:: https://landscape.io/github/marrow/mongo/develop/landscape.svg?style=flat
+    :target: https://landscape.io/github/marrow/mongo/develop
+    :alt: Develop Branch Code Health
 
 .. |cake| image:: http://img.shields.io/badge/cake-lie-1b87fb.svg?style=flat

--- a/marrow/mongo/query/q.py
+++ b/marrow/mongo/query/q.py
@@ -263,7 +263,7 @@ class Q(object):
 	# Multiple Field Participation
 	
 	def __and__(self, other):
-		"""Allow the comparison of multiple fields against a single value. (Not implemented yet.)
+		"""Allow the comparison of multiple fields against a single value.
 		
 		Binary "and" comparison: both fields must match the final expression.
 		
@@ -273,7 +273,7 @@ class Q(object):
 		raise NotImplementedError()  # pragma: no cover
 	
 	def __or__(self, other):
-		"""Allow the comparison of multiple fields against a single value. (Not implemented yet.)
+		"""Allow the comparison of multiple fields against a single value.
 		
 		Binary "or" comparison: either field, or both, match the final expression.
 		
@@ -283,7 +283,7 @@ class Q(object):
 		raise NotImplementedError()  # pragma: no cover
 	
 	def __xor__(self, other):
-		"""Allow the comparison of multiple fields against a single value. (Not implemented yet.)
+		"""Allow the comparison of multiple fields against a single value.
 		
 		Binary "xor" comparison: the first field, or the second field, but not both must match the expression.
 		

--- a/marrow/mongo/query/q.py
+++ b/marrow/mongo/query/q.py
@@ -11,6 +11,7 @@ import re
 from copy import copy, deepcopy
 from collections import Mapping, MutableMapping
 from operator import __and__, __or__, __xor__
+from functools import reduce
 from pytz import utc
 from bson.codec_options import CodecOptions
 from marrow.schema.compat import odict
@@ -413,6 +414,7 @@ class Q(object):
 		"""
 		
 		if self._combining:  # We are a field-compound query fragment, e.g. (Foo.bar & Foo.baz).
+			print("Combining", self._combining, self._field)
 			return reduce(self._combining, (q.range(gte, lt) for q in self._field))
 		
 		# Optimize this away in production; diagnosic aide.

--- a/marrow/mongo/query/q.py
+++ b/marrow/mongo/query/q.py
@@ -54,12 +54,11 @@ class Q(object):
 	* range
 	* re
 	* size
-	
-	A possible workaround is making Q callable (__call__) and pulling the final element off to determine method to call.
 	"""
 	
 	def __init__(self, document, field, path=None):
-		"""Do not construct instances of Q yourself.""" 
+		"""Do not construct instances of Q yourself."""
+		
 		self._document = document
 		self._field = field
 		self._name = (path or '') + unicode(field)

--- a/marrow/mongo/query/q.py
+++ b/marrow/mongo/query/q.py
@@ -139,7 +139,7 @@ class Q(object):
 		"""A basic operation operating on a single value."""
 		
 		if self._combining:  # We are a field-compound query fragment, e.g. (Foo.bar & Foo.baz).
-			return reduce(self._combining, (q._op(operation, other, *allowed) for q in self._field))
+			return reduce(self._combining, (q._op(operation, other, *allowed) for q in self._field))  # noqa
 		
 		# Optimize this away in production; diagnosic aide.
 		if __debug__ and _complex_safety_check(self._field, {operation} & set(allowed)):  # pragma: no cover
@@ -154,7 +154,7 @@ class Q(object):
 		"""
 		
 		if self._combining:  # We are a field-compound query fragment, e.g. (Foo.bar & Foo.baz).
-			return reduce(self._combining, (q._iop(operation, other, *allowed) for q in self._field))
+			return reduce(self._combining, (q._iop(operation, other, *allowed) for q in self._field))  # noqa
 		
 		# Optimize this away in production; diagnosic aide.
 		if __debug__ and _complex_safety_check(self._field, {operation} & set(allowed)):  # pragma: no cover
@@ -288,7 +288,7 @@ class Q(object):
 	
 	# Multiple Field Participation
 	
-	def _combine(self, other, operation):
+	def _combine(self, other, operation):  # pylint:disable=protected-access
 		if not isinstance(other, Q):
 			raise TypeError("Can not combine with non-Q.")
 		

--- a/marrow/mongo/query/q.py
+++ b/marrow/mongo/query/q.py
@@ -21,8 +21,10 @@ from .ops import Ops
 
 
 if __debug__:
-	_simple_safety_check = lambda s, o: (s.__allowed_operators__ and o not in s.__allowed_operators__) or o in s.__disallowed_operators__
-	_complex_safety_check = lambda s, o: (s.__allowed_operators__ and not s.__allowed_operators__.intersection(o)) or s.__disallowed_operators__.intersection(o)
+	_simple_safety_check = lambda s, o: (s.__allowed_operators__ and o not in s.__allowed_operators__) \
+			or o in s.__disallowed_operators__
+	_complex_safety_check = lambda s, o: (s.__allowed_operators__ and not s.__allowed_operators__.intersection(o)) \
+			or s.__disallowed_operators__.intersection(o)
 
 
 class Q(object):

--- a/marrow/mongo/query/q.py
+++ b/marrow/mongo/query/q.py
@@ -391,9 +391,6 @@ class Q(object):
 		if self._combining:  # We are a field-compound query fragment, e.g. (Foo.bar & Foo.baz).
 			return reduce(self._combining, (qp.match(q) for qp in self._field))
 		
-		if self._combining:
-			raise AttributeError()
-		
 		# Optimize this away in production; diagnosic aide.
 		if __debug__ and _complex_safety_check(self._field, {'$elemMatch', '#document'}):  # pragma: no cover
 			raise NotImplementedError("{self!r} does not allow $elemMatch comparison.".format(self=self))

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
 	author = author.name,
 	author_email = author.email,
 	license = 'MIT',
-	keywords = '',
+	keywords = ['mongodb', 'orm', 'odm', 'document mapper', 'declarative', 'marrow'],
 	classifiers = [
 			"Development Status :: 5 - Production/Stable",
 			"Intended Audience :: Developers",
@@ -68,6 +68,7 @@ setup(
 	include_package_data = True,
 	package_data = {'': ['README.rst', 'LICENSE.txt']},
 	namespace_packages = ['marrow', 'web', 'web.session'],
+	zip_safe = False,
 	
 	# ## Dependency Declaration
 	

--- a/test/query/test_q.py
+++ b/test/query/test_q.py
@@ -6,6 +6,7 @@ import pytest
 import operator
 from datetime import datetime
 from collections import OrderedDict as odict
+from bson import ObjectId as oid
 
 from marrow.mongo import Document, Field
 from marrow.mongo.field import String, Number, Array, Embed, ObjectId
@@ -159,6 +160,15 @@ class TestQueryableFieldCombinations(object):
 		
 		assert q.operations['$or'][0]['id']['$gte'] == q.operations['$or'][1]['reply.id']['$gte']
 		assert q.operations['$or'][0]['id']['$lt'] == q.operations['$or'][1]['reply.id']['$lt']
+	
+	def test_basic_op(self):
+		T = self.Thread
+		comb = T.id & T.reply.id
+		v = oid()
+		q = comb == v
+		
+		assert q.operations['id'] == v
+		assert q.operations['reply.id'] == v
 	
 	def test_combination_attribute_access_fails(self):
 		T = self.Thread

--- a/test/query/test_q.py
+++ b/test/query/test_q.py
@@ -135,5 +135,5 @@ class TestQueryable(object):  # TODO: Properly use pytest fixtures for this...
 			Sample.generic['foo']
 	
 	def test_array_non_numeric(self):
-		with pytest.raises(ValueError):
+		with pytest.raises(KeyError):
 			Sample.array['bar']


### PR DESCRIPTION
DRY de-duplication of shared right-hand comparison values.  For example:

```python
(Thread.id >= ObjectId.from_datetime(datetime.utcnow()-timedelta(days=7)) | \
    (Thread.reply.id >= ObjectId.from_datetime(datetime.utcnow()-timedelta(days=7)))
```

Can be simplified to:

```python
(Thread.id | Thread.reply.id) >= -timedelta(days=7)
```

(Representing all forum threads created or replied to within the last 7 days.)