### PR TITLE
Array reference support.

### DIFF
--- a/marrow/mongo/core/field/complex.py
+++ b/marrow/mongo/core/field/complex.py
@@ -197,3 +197,53 @@ class PluginReference(Field):
 			raise ValueError(repr(value) + ' object is not a known plugin for namespace "' + namespace + '".')
 		
 		return plugins.get(value, canon(value))
+
+
+class Alias(Attribute):
+	"""Reference a field, potentially nested, elsewhere in the document.
+	
+	This provides a shortcut for querying nested fields, for example, in GeoJSON, to more easily access the latitude
+	and longitude:
+	
+		class Point(Document):
+			kind = String('type', default='point', assign=True)
+			coordinates = Array(Number(), default=lambda: [0, 0], assign=True)
+			latitude = Alias('coordinates.1')
+			longitude = Alias('coordinates.0')
+	
+	You can now read and write `latitude` and `longitude` on instances of `Point`, as well as query the nested values
+	through class attribute access.
+	"""
+	
+	path = Attribute()
+	path.__sequence__ -= 10000
+	
+	def __init__(self, path):
+		super(Alias, self).__init__(path=path)
+	
+	def __fixup__(self, document):
+		"""Called after an instance of our Field class is assigned to a Document."""
+		self.__document__ = proxy(document)
+	
+	def __get__(self, obj, cls=None):
+		if obj is None:
+			return traverse(self.__document__, self.path)
+		
+		return traverse(obj, self.path)
+	
+	def __set__(self, obj, value):
+		parts = self.path.split('.')
+		final = parts.pop()
+		current = obj
+		
+		for part in parts:
+			if part.lstrip('-').isdigit():
+				current = current[int(part)]
+				continue
+			
+			current = getattr(current, part)
+		
+		if final.lstrip('-').isdigit():
+			current[int(final)] = value
+		else:
+			setattr(current, final, value)

--- a/marrow/mongo/core/field/complex.py
+++ b/marrow/mongo/core/field/complex.py
@@ -3,6 +3,7 @@
 from bson import DBRef, ObjectId as oid
 from collections import Iterable
 from pkg_resources import iter_entry_points
+from weakref import proxy
 
 from marrow.schema import Attribute
 from marrow.package.canonical import name as canon
@@ -45,7 +46,10 @@ class _CastingKind(Field):
 			kinds = list(self.kinds)
 			
 			if len(kinds) == 1:
-				value = kinds[0].from_mongo(value)
+				if hasattr(kinds[0], 'transformer'):
+					value = kinds[0].transformer.native(value, (kinds[0], obj))
+				else:
+					value = kinds[0].from_mongo(value)
 			else:
 				value = Document.from_mongo(value)  # TODO: Pass in allowed classes.
 		
@@ -73,20 +77,46 @@ class Array(_HasKinds, _CastingKind, Field):
 	__foreign__ = 'array'
 	__allowed_operators__ = {'#array', '$elemMatch'}
 	
+	class List(list):
+		pass
+	
 	def to_native(self, obj, name, value):
 		"""Transform the MongoDB value into a Marrow Mongo value."""
 		
-		return [super(Array, self).to_native(obj, name, i) for i in value]
+		if isinstance(value, self.List):
+			return value
+		
+		result = self.List(super(Array, self).to_native(obj, name, i) for i in value)
+		obj.__data__[self.__name__] = result
+		
+		return result
 	
 	def to_foreign(self, obj, name, value):
 		"""Transform to a MongoDB-safe value."""
 		
-		return [super(Array, self).to_foreign(obj, name, i) for i in value]
+		return self.List(super(Array, self).to_foreign(obj, name, i) for i in value)
 
 
 class Embed(_HasKinds, _CastingKind, Field):
 	__foreign__ = 'object'
 	__allowed_operators__ = {'#document'}
+	
+	def to_native(self, obj, name, value):
+		"""Transform the MongoDB value into a Marrow Mongo value."""
+		
+		if isinstance(value, Document):
+			return value
+		
+		result = super(Embed, self).to_native(obj, name, value)
+		obj.__data__[self.__name__] = result
+		
+		return result
+	
+	def to_foreign(self, obj, name, value):
+		"""Transform to a MongoDB-safe value."""
+		
+		result = super(Embed, self).to_foreign(obj, name, value)
+		return result
 
 
 class Reference(_HasKinds, Field):
@@ -216,7 +246,6 @@ class Alias(Attribute):
 	"""
 	
 	path = Attribute()
-	path.__sequence__ -= 10000
 	
 	def __init__(self, path):
 		super(Alias, self).__init__(path=path)

--- a/marrow/mongo/query/q.py
+++ b/marrow/mongo/query/q.py
@@ -93,7 +93,8 @@ class Q(object):
 			Person.tag[3] == "baz"
 		"""
 		
-		from marrow.mongo import Document, Field, Embed
+		from marrow.mongo import Document, Field
+		from marrow.mongo.field import Embed
 		
 		if self._field.__foreign__ != 'array':  # Pass through if not an array type field.
 			return self._field[name]

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
 						'Embed = marrow.mongo.core.field.complex:Embed',
 						'Reference = marrow.mongo.core.field.complex:Reference',
 						'PluginReference = marrow.mongo.core.field.complex:PluginReference',
+						'Alias = marrow.mongo.core.field.complex:Alias',
 						'Number = marrow.mongo.core.field.number:Number',
 						'Double = marrow.mongo.core.field.number:Double',
 						'Integer = marrow.mongo.core.field.number:Integer',

--- a/test/field/test_alias.py
+++ b/test/field/test_alias.py
@@ -1,0 +1,95 @@
+# encoding: utf-8
+
+from __future__ import unicode_literals
+
+import pytest
+
+from marrow.mongo import Document
+from marrow.mongo.field import Alias, Array, String, Embed
+from marrow.mongo.util.compat import unicode
+
+
+class TestAliasDirect(object):
+	class Sample(Document):
+		field = String()
+		alias = Alias('field')
+	
+	def test_query_reference(self):
+		q = self.Sample.alias
+		assert ~q == "field"
+		assert isinstance(q._field, String)
+	
+	def test_data_access(self):
+		inst = self.Sample.from_mongo({'field': 'foo'})
+		assert inst.alias == 'foo'
+	
+	def test_data_assignment(self):
+		inst = self.Sample()
+		inst.alias = 'bar'
+		assert inst.__data__ == {'field': 'bar'}
+
+
+class TestAliasArray(object):
+	class Sample(Document):
+		field = Array(String())
+		alias = Alias('field.0')
+	
+	def test_query_reference(self):
+		q = self.Sample.alias
+		assert ~q == "field.0"
+		assert isinstance(q._field, String)
+	
+	def test_data_access(self):
+		inst = self.Sample.from_mongo({'field': ['foo']})
+		assert inst.alias == 'foo'
+	
+	def test_data_assignment(self):
+		inst = self.Sample.from_mongo({'field': ['foo']})
+		inst.alias = 'bar'
+		assert inst.__data__ == {'field': ['bar']}
+
+
+class TestAliasEmbed(object):
+	class Sample(Document):
+		class Embedded(Document):
+			field = String()
+		
+		field = Embed(Embedded)
+		alias = Alias('field.field')
+	
+	def test_query_reference(self):
+		q = self.Sample.alias
+		assert ~q == "field.field"
+		assert isinstance(q._field, String)
+	
+	def test_data_access(self):
+		inst = self.Sample.from_mongo({'field': {'field': 'foo'}})
+		assert inst.alias == 'foo'
+	
+	def test_data_assignment(self):
+		inst = self.Sample().from_mongo({'field': {}})
+		inst.alias = 'bar'
+		assert inst.__data__ == {'field': {'field': 'bar'}}
+
+
+class TestAliasArrayEmbed(object):
+	class Sample(Document):
+		class Embedded(Document):
+			field = String()
+		
+		field = Array(Embedded)
+		alias = Alias('field.0.field')
+	
+	def test_query_reference(self):
+		q = self.Sample.alias
+		assert ~q == "field.0.field"
+		assert isinstance(q._field, String)
+	
+	def test_data_access(self):
+		inst = self.Sample.from_mongo({'field': [{'field': 'foo'}]})
+		assert inst.alias == 'foo'
+	
+	def test_data_assignment(self):
+		inst = self.Sample.from_mongo({'field': [{'field': 'foo'}]})
+		inst.alias = 'bar'
+		assert inst.__data__ == {'field': [{'field': 'bar'}]}

--- a/test/query/test_q.py
+++ b/test/query/test_q.py
@@ -129,3 +129,11 @@ class TestQueryable(object):  # TODO: Properly use pytest fixtures for this...
 	def test_match_query(self):
 		result = Sample.array.match(Sample.Embedded.name == "Alice")
 		assert result.as_query == {'field_name': {'$elemMatch': {'name': "Alice"}}}
+	
+	def test_non_array_passthrough(self):
+		with pytest.raises(TypeError):
+			Sample.generic['foo']
+	
+	def test_array_non_numeric(self):
+		with pytest.raises(ValueError):
+			Sample.array['bar']


### PR DESCRIPTION
Allow querying specific array elements, both exact (shallow) and nested (deep). Examples include:

* `Person.tag[3] == "baz"` — a filter document to find documents whose fourth tag is `baz`.
* `{'$unset': {~Person.tag[0]: True}}` — delete the first tag
* `Foo.bar[0].baz` — reference a specific embedded document's value