### PR TITLE
Class inheritance promotion/demotion.

### DIFF
--- a/marrow/mongo/core/document.py
+++ b/marrow/mongo/core/document.py
@@ -170,6 +170,18 @@ class Document(Container):
 		
 		return self  # We're sufficiently dictionary-like to pass muster.
 	
+	# Object Heirarchy Utilities
+	
+	def _promote(self, other):
+		"""Promote an instance of one document class to an instance of a child class."""
+		
+		pass
+	
+	def _demote(self, other=None):
+		"""Demote an instance of one document class to an instance of one of its parent classes."""
+		
+		pass
+	
 	# Mapping Protocol
 	
 	def __getitem__(self, name):


### PR DESCRIPTION
As an example in [BDD](http://en.wikipedia.org/wiki/Behavior_Driven_Development) style:

- **Given** three _classes_: `Asset(Document)`, `Folder(Asset)`, `Gallery(Folder)`.
- **And given** an _instance_ of `Folder`.
  - **When** the system _promotes_ the `Folder` instance to `Gallery`.
    - **Then** a new _instance_ of type `Gallery` should be returned.
    - **And then** old _instances_ (from caches, say) should be invalidated.  [Attempts to use these should result in exceptions.]
    - **And then** data values common to both classes should be transferred.  [E.g. `name` is common to both.]
  - **When** the system _demotes_ the `Folder` instance to `Asset`. [This may not be specific; if a class isn't specified it defaults to the immediate parent class.]
    - **Then** a new _instance_ of type `Asset` should be returned.
    - **And then** old _instances_ (from caches, say) should be invalidated.
    - **And then** data values common to both classes should be transferred.
    - **And then** data values not common should optionally be removed from the underlying record.  [This is not possible when promoting as you can't "delete" existing definitions, only override them.  E.g. the `view` (list, icon, etc.) would be deleted.]

The second is needed for the use case of demoting a `User` subclass instance back up to `User`, then promoting it down to a different subclass in order to change the capabilities and data-based "role" of the given user.

There is also the possibility of automatically working out (via `type(Foo).mro()` inspection) the nearest common root between two arbitrary classes, then working down and back up to mutate more widely.  If the common root is `Document`, this is an error (unless the developer decides to preserve unknown fields, or removal is _very_ explicitly requested) as the classes are not related at all and thus no data would be preserved during migration.

Redefinition of a field with differing types between a parent and child class would be a _bad thing_ if the field's Python (native) values were not compatible.  Sometimes they are; e.g. `ObjectId` and `Date` fields (yes, really), or `Integer` and `Double` for something more reasonable.

Here are some code snippets:

``` javascript
// Demote
db.foo.update(
	{_id: ObjectId('…')},
	{$set: {_cls: 'Foo'}, $pop: {_types: 1}},
	false, false);

// Promote
db.foo.update(
	{_id: ObjectId('…')},
	{$set: {_cls: 'Foo.Bar'}, $push: {_types: 'Bar'}},
	false, false);
```