### PR TITLE
Decimal support.

### DIFF
--- a/marrow/mongo/core/field/number.py
+++ b/marrow/mongo/core/field/number.py
@@ -49,7 +49,7 @@ class Long(Number):
 
 
 try:
-	from decimal import Decimal, localcontext
+	from decimal import Decimal as dec, localcontext
 	from bson.decimal128 import Decimal128, create_decimal128_context
 
 except ImportError:  # pragma: no cover
@@ -65,10 +65,10 @@ else:
 			if hasattr(value, 'to_decimal'):
 				return value.to_decimal()
 			
-			return Decimal(value)
+			return dec(value)
 		
 		def to_foreign(self, obj, name, value):  # pylint:disable=unused-argument
-			if not isinstance(value, Decimal):
+			if not isinstance(value, dec):
 				with localcontext(self.DECIMAL_CONTEXT) as ctx:
 					value = ctx.create_decimal(value)
 			

--- a/marrow/mongo/core/field/number.py
+++ b/marrow/mongo/core/field/number.py
@@ -52,7 +52,7 @@ try:
 	from decimal import Decimal, localcontext
 	from bson.decimal128 import Decimal128, create_decimal128_context
 
-except ImportError:
+except ImportError:  # pragma: no cover
 	Decimal = None
 
 else:

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
 		],
 	
 	extras_require = dict(
+			decimal = ['pymongo>=3.4'],  # More modern version required for Decimal128 support.
 			development = tests_require + ['pre-commit'],  # Development-time dependencies.
 			scripting = ['javascripthon<1.0'],  # Allow map/reduce functions and "stored functions" to be Python.
 			logger = ['tzlocal'],  # Timezone support to store log times in UTC like a sane person.
@@ -127,6 +128,7 @@ setup(
 						'Double = marrow.mongo.core.field.number:Double',
 						'Integer = marrow.mongo.core.field.number:Integer',
 						'Long = marrow.mongo.core.field.number:Long',
+						'Decimal = marrow.mongo.core.field.number:Decimal[decimal]',
 					],
 				# ### WebCore Extensions
 				'web.session': [  # Session Engine

--- a/test/field/test_number.py
+++ b/test/field/test_number.py
@@ -90,3 +90,10 @@ class TestDecimalField(FieldExam):
 		assert isinstance(result['field'], Decimal128)
 		assert result['field'] == Decimal128('3.141592')
 		assert result.field == v
+	
+	def test_decimal_cast_up(self, Sample):
+		from marrow.package.canonical import name
+		result = Sample.from_mongo({'field': 27.4})
+		v = result.field
+		assert isinstance(v, dec)
+		assert float(v) == 27.4

--- a/test/field/test_number.py
+++ b/test/field/test_number.py
@@ -3,13 +3,15 @@
 from __future__ import unicode_literals
 
 from datetime import datetime, timedelta
+from decimal import Decimal as dec
 
 import pytest
 from bson import ObjectId as oid
+from bson.decimal128 import Decimal128
 from bson.tz_util import utc
 
 from marrow.mongo import Document
-from marrow.mongo.field import Double, Integer, Long, Number
+from marrow.mongo.field import Decimal, Double, Integer, Long, Number
 from marrow.schema.compat import unicode
 
 
@@ -77,3 +79,14 @@ class TestLongField(FieldExam):
 	def test_biginteger(self, Sample):
 		result = Sample(272787482374844672646272463).field
 		assert result == 272787482374844672646272463
+
+
+class TestDecimalField(FieldExam):
+	__field__ = Decimal
+	
+	def test_decimal(self, Sample):
+		v = dec('3.141592')
+		result = Sample(v)
+		assert isinstance(result['field'], Decimal128)
+		assert result['field'] == Decimal128('3.141592')
+		assert result.field == v

--- a/test/field/test_number.py
+++ b/test/field/test_number.py
@@ -92,8 +92,13 @@ class TestDecimalField(FieldExam):
 		assert result.field == v
 	
 	def test_decimal_cast_up(self, Sample):
-		from marrow.package.canonical import name
 		result = Sample.from_mongo({'field': 27.4})
 		v = result.field
 		assert isinstance(v, dec)
 		assert float(v) == 27.4
+	
+	def test_decimal_from_number(self, Sample):
+		result = Sample(27)
+		assert isinstance(result['field'], Decimal128)
+		assert result['field'] == Decimal128('27')
+		assert int(result.field) == 27


### PR DESCRIPTION
Now that MongoDB 3.4 is out (yay!) we need to add support for [`Decimal128`](http://api.mongodb.com/python/current/api/bson/decimal128.html#bson.decimal128.Decimal128).  This does that.

Note that this field is conditional on having PyMongo 3.4 or later; Marrow Mongo still only requires 3.2. Attempts to `from marrow.mongo.field import Decimal` on an earlier version will result in a `VersionConflict` exception.

(To see how this type of conditional field is done, check the setup.py entry points and extras require.)