### PR TITLE
Heirarchical traits, cleanup, fixes, and improvements.

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: /env,.eggs,.packaging,.cache

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 	rm -rvf build htmlcov
 
 veryclean: clean
-	rm -rvf *.egg-info .packaging
+	rm -rvf *.egg-info .packaging/*
 
 test: develop
 	@clear
@@ -28,4 +28,3 @@ release:
 ${PROJECT}.egg-info/PKG-INFO: setup.py setup.cfg marrow/mongo/core/release.py
 	@mkdir -p ${VIRTUAL_ENV}/lib/pip-cache
 	pip install --cache-dir "${VIRTUAL_ENV}/lib/pip-cache" -Ue ".[${USE}]"
-

--- a/marrow/mongo/core/field/array.py
+++ b/marrow/mongo/core/field/array.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from ... import Document, Field
+from ... import Field
 from .base import _HasKind, _CastingKind
 
 
@@ -29,6 +29,9 @@ class Array(_HasKind, _CastingKind, Field):
 		if isinstance(value, self.List):
 			return value
 		
+		if value is None:
+			return None
+		
 		result = self.List(super(Array, self).to_native(obj, name, i) for i in value)
 		obj.__data__[self.__name__] = result
 		
@@ -36,5 +39,8 @@ class Array(_HasKind, _CastingKind, Field):
 	
 	def to_foreign(self, obj, name, value):
 		"""Transform to a MongoDB-safe value."""
+		
+		if value is None:
+			return None
 		
 		return self.List(super(Array, self).to_foreign(obj, name, i) for i in value)

--- a/marrow/mongo/core/field/date.py
+++ b/marrow/mongo/core/field/date.py
@@ -1,18 +1,112 @@
 # encoding: utf-8
 
+"""Marrow Mongo Date field specialization.
+
+Commentary on high-level management of timezone casting:
+
+	https://groups.google.com/forum/#!topic/mongodb-user/GOMjTJON4cg
+"""
+
 from __future__ import unicode_literals
 
-from bson import ObjectId
+from datetime import datetime, timedelta, tzinfo
+from bson import ObjectId as OID
+from collections import MutableMapping
+from datetime import datetime, timedelta
 
 from .base import Field
+from ...util import utc, utcnow
+from ....schema import Attribute
+
+# Conditional dependencies.
+
+try:
+	from pytz import timezone as get_tz
+except ImportError:
+	get_tz = None
+
+try:
+	localtz = __import__('tzlocal').get_localzone()
+except ImportError:
+	localtz = None
+
+
+log = __import__('logging').getLogger(__name__)
 
 
 class Date(Field):
+	"""MongoDB date/time storage.
+	
+	Accepts the following options in addition to the base Field options:
+	
+	`naive`: The timezone to interpret assigned "naive" datetime objects as.
+	`timezone`: The timezone to cast objects retrieved from the database to.
+	
+	Timezone references may be, or may be a callback returning, a `tzinfo`-suitable object, the string name of a
+	timezone according to `pytz`, the alias 'naive' (strip or ignore the timezone) or 'local' (the local host's)
+	timezone explicitly. None values imply no conversion.
+	
+	All dates are converted to and stored in UTC for storage within MongoDB; the original timezone is lost. As a
+	result if `naive` is `None` then assignment of naive `datetime` objects will fail.
+	"""
+	
 	__foreign__ = 'date'
 	__disallowed_operators__ = {'#array'}
 	
-	def to_foreign(self, obj, name, value):  # pylint:disable=unused-argument
-		if isinstance(value, ObjectId):
-			return value.generation_time
+	naive = Attribute(default=utc)
+	tz = Attribute(default=None)  # Timezone to cast to when retrieving from the database.
+	
+	def _process_tz(self, dt, naive, tz):
+		"""Process timezone casting and conversion."""
 		
-		return value
+		def _tz(t):
+			if t is None:
+				return
+			
+			if t == 'local':
+				if __debug__ and not localtz:
+					raise ValueError("Requested conversion to local timezone, but `localtz` not installed.")
+				
+				t = localtz
+			
+			if not isinstance(t, tzinfo):
+				t = get_tz(t)
+			
+			if not hasattr(t, 'normalize'):  # Attempt to handle non-pytz tzinfo.
+				t = get_tz(t.tzname())
+			
+			return t
+		
+		naive = _tz(naive)
+		tz = _tz(tz)
+		
+		if not dt.tzinfo and naive:
+			dt = naive.localize(dt)
+		
+		if tz:
+			dt = tz.normalize(dt.astimezone(tz))
+		
+		return dt
+	
+	def to_native(self, obj, name, value):
+		if not isinstance(value, datetime):
+			log.warn("Non-date stored in {}.{} field.".format(self.__class__.__name__, ~self),
+					extra={'document': obj, 'field': ~self, 'value': value})
+			return value
+		
+		return self._process_tz(value, self.naive, self.tz)
+	
+	def to_foreign(self, obj, name, value):  # pylint:disable=unused-argument
+		if isinstance(value, MutableMapping) and '_id' in value:
+			value = value['_id']
+		
+		if isinstance(value, OID):
+			value = value.generation_time
+		
+		elif isinstance(value, timedelta):
+			value = utcnow() + value
+		
+		assert isinstance(value, datetime), "Value must be a datetime, ObjectId, or identified document, not: " + \
+				repr(value)
+		
+		return self._process_tz(value, self.naive, utc)

--- a/marrow/mongo/core/field/ttl.py
+++ b/marrow/mongo/core/field/ttl.py
@@ -16,15 +16,13 @@ class TTL(Date):
 	__disallowed_operators__ = {'#array'}
 	
 	def to_foreign(self, obj, name, value):
-		value = super(TTL, self).to_foreign(obj, name, value)
-		
 		if isinstance(value, timedelta):
-			return utcnow() + value
+			value = utcnow() + value
+		elif isinstance(value, datetime):
+			value = value
+		elif isinstance(value, Number):
+			value = utcnow() + timedelta(days=value)
+		else:
+			raise ValueError("Invalid TTL value: " + repr(value))
 		
-		if isinstance(value, datetime):
-			return value
-		
-		if isinstance(value, Number):
-			return utcnow() + timedelta(days=value)
-		
-		raise ValueError("Invalid TTL value: " + repr(value))
+		return super(TTL, self).to_foreign(obj, name, value)

--- a/marrow/mongo/core/trait/heir/base.py
+++ b/marrow/mongo/core/trait/heir/base.py
@@ -75,6 +75,9 @@ class Heirarchical(Queryable):
 	# Internal Use Methods
 	
 	def _find_heirarchical(self, accessor, *args, **kw):
+		# TODO: Refactor as callable class level accessor object.
+		# Queryable.objects([pk or sequence or fragment]=None, *fragment, **kw)
+		
 		try:
 			query = getattr(self, accessor)
 			
@@ -97,6 +100,8 @@ class Heirarchical(Queryable):
 	
 	@contextmanager
 	def _heir_update(self):
+		# TODO: Refactor as Queryable.objects.bulk(ordered=False) method.
+		
 		ops = self.get_collection().initialize_ordered_bulk_op()
 		
 		yield ops
@@ -105,7 +110,7 @@ class Heirarchical(Queryable):
 			ops.execute()
 		except:
 			__import__('pprint').pprint(e.details)
-			raise
+			raise  # TODO: We can do better than the above.
 	
 	# Active Collection Methods
 	
@@ -147,8 +152,16 @@ class Heirarchical(Queryable):
 		return self
 	
 	def _attach(self, child, ops, project=None):
+		"""Perform the work of attaching this document, to be overridden in subclasses.
+		
+		Subclasses should super() early and utilize the result in order to benefit from automatic casting. Provided
+		a reference to the child to attach, an ordered bulk operations object, and optional default projection.
+		"""
+		
+		# TODO: Refactor to isolate this as common to all cooperative attachment methods.
+		
 		if not isinstance(child, Document):
-			child = Doc.find_one(child, project=project)
+			child = Doc.find_one(child, project=project)  # TODO: Utilize Queryable default projection.
 		
 		return child
 	
@@ -164,15 +177,17 @@ class Heirarchical(Queryable):
 		"""Attach this document (with any descendants) to the given parent."""
 		
 		if not isinstance(parent, Document):
-			parent = self.find_one(parent)
+			parent = self.find_one(parent)  # TODO: Utilize Queryable default projection.
 		
 		return parent.attach(self)
 	
 	def attach_before(self, sibling):
 		"""Attach this document (with any descendants) to the same parent as the target sibling, prior to that sibling."""
 		
+		# TODO: Utilize _attach/attach refactor.
+		
 		if not isinstance(sibling, Document):
-			sibling = self.find_one(sibling, project=('parent', ))
+			sibling = self.find_one(sibling)  # TODO: Utilize Queryable default projection.
 		
 		self.attach_to(sibling.parent)
 		
@@ -181,8 +196,10 @@ class Heirarchical(Queryable):
 	def attach_after(self, sibling):
 		"""Attach this document (with any descendants) to the same parent as the target sibling, after that sibling."""
 		
+		# TODO: Utilize _attach/attach refactor.
+		
 		if not isinstance(sibling, Document):
-			sibling = self.find_one(sibling, project=('parent', ))
+			sibling = self.find_one(sibling)  # TODO: Utilize Queryable default projection.
 		
 		self.attach_to(sibling.parent)
 		

--- a/marrow/mongo/core/trait/heir/base.py
+++ b/marrow/mongo/core/trait/heir/base.py
@@ -1,0 +1,189 @@
+# encoding: utf-8
+
+from contextlib import contextmanager
+
+from .... import Document
+from ....trait import Queryable
+
+
+log = __import__('logging').getLogger(__name__)
+
+
+class Heirarchical(Queryable):
+	"""Record sufficient information to form a heirarchy of documents.
+	
+	Inteded for use via subclassing; not directly usable. This contains API prototypes and mixin methods similar in
+	function to an abstract base class. For the most part subclasses should be able to "get away with" overriding
+	appropriate accessor properties with real fields, or by providing alternate properties returning query fragments.
+	
+	A subclass should not, except under extreme circumstances, override the actual `find_` and `attach` methods.
+	"""
+	
+	# Accessor Properties
+	
+	@property
+	def parent(self):
+		"""The primary key identity of, or query fragment to select the parent of this document.
+		
+		The result of a `ReferenceField('.')` is sufficient to satisfy this, if redefined as one.
+		
+		Used by `get_parent` as passed as the first positional argument to `find_one`.
+		"""
+		
+		raise NotImplementedError()
+	
+	@property
+	def ancestors(self):
+		"""A query fragment or iterable of primary key identifiers to select the ancestors of this document.
+		
+		The result of an `Array(ReferenceField('.'))` is sufficient to satisfy this, if redefined as one.
+		
+		Used by `get_ancestors` with behaviour defined by `_find_heirarchical`.
+		"""
+		
+		raise NotImplementedError()
+	
+	@property
+	def siblings(self):
+		"""A query fragment or iterable of primary key identifiers to select the siblings of this document.
+		
+		Used by `get_siblings` with behaviour defined by `_find_heirarchical`.
+		"""
+		
+		raise NotImplementedError()
+	
+	@property
+	def children(self):
+		"""A query fragment or iterable of primary key identifiers to select the children of this document.
+		
+		The result of an `Array(ReferenceField('.'))` is sufficient to satisfy this, if redefined as one.
+		
+		Used by `get_children` with behaviour defined by `_find_heirarchical`.
+		"""
+		
+		raise NotImplementedError()
+	
+	@property
+	def descendants(self):
+		"""A query fragment or iterable of primary key identifiers to select the descendants of this document.
+		
+		Used by `get_descendants` with behaviour defined by `_find_heirarchical`.
+		"""
+		
+		raise NotImplementedError()
+	
+	# Internal Use Methods
+	
+	def _find_heirarchical(self, accessor, *args, **kw):
+		try:
+			query = getattr(self, accessor)
+			
+			if not isinstance(query, Filter):
+				query = list(query)
+		
+		except TypeError:
+			query = None
+		
+		if not query:
+			return None
+		
+		if isinstance(query, list):
+			iterator = self.find_in_sequence(self.__pk__, query, *args, **kw)
+		
+		else:
+			iterator = self.find(query, *args, **kw)
+		
+		return (self.from_mongo(record) for record in iterator)
+	
+	@contextmanager
+	def _heir_update(self):
+		ops = self.get_collection().initialize_ordered_bulk_op()
+		
+		yield ops
+		
+		try:
+			ops.execute()
+		except:
+			__import__('pprint').pprint(e.details)
+			raise
+	
+	# Active Collection Methods
+	
+	def get_parent(self, *args, **kw):
+		"""Retrieve the Document instance representing the immediate parent of this document."""
+		
+		parent = self.parent
+		
+		if parent is None:
+			return None
+		
+		return self.find_one(parent, *args, **kw)
+	
+	def find_ancestors(self, *args, **kw):
+		"""Retrieve the Document instances representing the ancestors of this document."""
+		
+		return self._find_heirarchical('ancestors', *args, **kw)
+	
+	def find_siblings(self, *args, **kw):
+		"""Retrieve the Document instances representing siblings of this document, excluding this document."""
+		
+		return self._find_heirarchical('siblings', *args, id__ne=self.id, **kw)
+	
+	def find_children(self, *args, **kw):
+		"""Find the immediate children of this document."""
+		
+		return self._find_heirarchical('children', *args, **kw)
+	
+	def find_descendants(self, *args, **kw):
+		"""Prepare a MongoDB QuerySet searching for all descendants of this document."""
+		
+		return self._find_heirarchical('descendants', *args, **kw)
+	
+	# Active Document Methods
+	
+	def detach(self):
+		"""Detach this document from its tree, forming the root of a new tree containing this document and its children."""
+		
+		return self
+	
+	def _attach(self, child, ops, project=None):
+		if not isinstance(child, Document):
+			child = Doc.find_one(child, project=project)
+		
+		return child
+	
+	def attach(self, child, **kw):
+		"""Attach the given child document (with any descendants) to this document."""
+		
+		with self._heir_update(**kw) as ops:
+			self._attach(child, ops)
+		
+		return self
+	
+	def attach_to(self, parent):
+		"""Attach this document (with any descendants) to the given parent."""
+		
+		if not isinstance(parent, Document):
+			parent = self.find_one(parent)
+		
+		return parent.attach(self)
+	
+	def attach_before(self, sibling):
+		"""Attach this document (with any descendants) to the same parent as the target sibling, prior to that sibling."""
+		
+		if not isinstance(sibling, Document):
+			sibling = self.find_one(sibling, project=('parent', ))
+		
+		self.attach_to(sibling.parent)
+		
+		return self.reload()
+	
+	def attach_after(self, sibling):
+		"""Attach this document (with any descendants) to the same parent as the target sibling, after that sibling."""
+		
+		if not isinstance(sibling, Document):
+			sibling = self.find_one(sibling, project=('parent', ))
+		
+		self.attach_to(sibling.parent)
+		
+		return self.reload()

--- a/marrow/mongo/core/trait/heir/hparent.py
+++ b/marrow/mongo/core/trait/heir/hparent.py
@@ -1,0 +1,74 @@
+# encoding: utf-8
+
+from re import escape
+from pymongo.errors import BulkWriteError
+
+from .base import Heirarchical
+from .... import Document, Index, U
+from ....field import Path
+
+
+log = __import__('logging').getLogger(__name__)
+
+
+class HParent(Heirarchical):
+	"""Record sufficient information to form an orderless heirarchy of documents using parent association.
+	
+	This models the tree with a document per node and nodes containing a concrete list of child references.
+	
+	Ref: https://docs.mongodb.com/manual/tutorial/model-tree-structures-with-parent-references/
+	"""
+	
+	parent = Reference('.', default=None, assign=True)
+	
+	_parent = Index('parent')
+	
+	def get_parent(self, *args, **kw):
+		"""Retrieve the Document instance representing the immediate parent of this document."""
+		
+		if not self.parent:  # We can save time.
+			return None
+		
+		return self.find_one(self.parent, *args, **kw)
+	
+	def find_siblings(self, *args, **kw):
+		"""Prepare a MongoDB QuerySet searching the siblings of this document, excluding this document."""
+		
+		Doc, collection, query, options = self._prepare_find(*args, parent=self.parent, id__ne=self.id, **kw)
+		return collection.find(query, **options)
+	
+	def find_children(self, *args, **kw):
+		"""Prepare a MongoDB QuerySet searching for immediate children of this document."""
+		
+		if __debug__:
+			log.debug("Finding children by parent association: " + str(self.id), extra={'parent': self})
+		
+		Doc, collection, query, options = self._prepare_find(*args, parent=self, **kw)
+		return collection.find(query, **options)
+	
+	def detach(self):
+		"""Detach this document from its tree, forming the root of a new tree containing this document and its children."""
+		
+		self = super(HParent, self).detach()
+		
+		if not self.parent:
+			return self
+		
+		Doc, collection, query, options = self._prepare_find(id=self.id)
+		result = collection.update_one(query, U(Doc, parent=None))
+		
+		self.parent = None  # Clean up to save needing to reload the record.
+		
+		return self
+	
+	def attach(self, child):
+		"""Attach the given child document (with any descendants) to this document."""
+		
+		child = super(HParent, self).attach(child)
+		
+		Doc, collection, query, options = self._prepare_find(id=child.id)
+		result = collection.update_one(query, U(Doc, parent=self.id))
+		
+		child.parent = self.id  # Clean up to save needing to reload the record.
+		
+		return child

--- a/marrow/mongo/core/trait/heir/hpath.py
+++ b/marrow/mongo/core/trait/heir/hpath.py
@@ -1,0 +1,200 @@
+# encoding: utf-8
+
+from itertools import chain
+from re import escape
+from pathlib import PurePosixPath
+
+from .base import Heirarchical
+from .... import Index, U
+from ....field import Path
+
+
+log = __import__('logging').getLogger(__name__)
+
+
+class HPath(Heirarchical):
+	"""Record sufficient information to form an orderless heirarchy of documents using materialzied paths.
+	
+	This models the tree with a document per node and nodes containing a concrete list of child references.
+	
+	When mixing Heirarchical traits, use more efficient parent/child mix-ins later in your subclass definition.
+	
+	Ref: https://docs.mongodb.com/manual/tutorial/model-tree-structures-with-materialized-paths/
+	"""
+	
+	__pk__ = 'path'  # Pivot short-form queries to query the path, not ID.
+	
+	path = Path(required=True, repr=False)  # The coalesced path to the document.
+	
+	_path = Index('path', unique=True)
+	
+	# Accessor Properties
+	
+	@property
+	def parent(self):
+		"""A query fragment to select the parent of this document.
+		
+		Used by `get_parent` as passed as the first positional argument to `find_one`.
+		"""
+		
+		if __debug__:
+			log.debug("Finding parent by materialized path: " + str(self.path), extra={'document': self})
+		
+		path = self.path
+		
+		if not path or path == path.parent or str(path.parent) == '.':
+			return None  # No path, already root, or top level relative; no parent.
+		
+		return self.__class__.path == path.parent
+	
+	@property
+	def ancestors(self):
+		"""A query fragment selecting for the ancestors of this document, or a generator of parent path references.
+		
+		Warning: if you change the `__pk__` from `path`, the results will be unordered unless you explicitly sort on
+		the `path` field yourself. With a `__pk__` of `path` this will return a generator of references for ordered
+		selection by `_find_heirarchical`, otherwise it returns a query fragment filtering by possible paths.
+		
+		Used by `get_ancestors` with behaviour defined by `_find_heirarchical`.
+		"""
+		
+		if __debug__:
+			log.debug("Finding ancestors by materialized path: " + str(self.path), extra={'document': self})
+		
+		path = self.path
+		
+		if not path or path == path.parent or str(path.parent) == '.':
+			return None  # No path, already root, or top level relative; no parents.
+		
+		absolute = self.path.is_absolute()
+		parents = (parent for parent in self.path.parents if absolute or parent.name)
+		
+		if self.__pk__ != 'path':  # Warning: requires manual sort on `path` to preserve order!
+			return self.__class__.path.any(parents)
+		
+		return parents  # We can just return the generator directly for consumption by `_find_heirarchical`.
+	
+	@property
+	def siblings(self):
+		"""A query fragment selecting for the siblings of this document.
+		
+		Used by `get_siblings` with behaviour defined by `_find_heirarchical`.
+		"""
+		
+		if __debug__:
+			log.debug("Finding siblings by materialized path: " + str(self.path), extra={'document': self})
+		
+		path = self.path
+		
+		if not path or path == path.parent or str(path.parent) == '.':
+			return None  # No path, already root, or top level relative; no siblings.
+		
+		return self.__class__.path.re(r'^', escape(str(self.path.parent)), r'\/[^\/]+$')
+	
+	@property
+	def children(self):
+		"""A query fragment selecting for the immediate children of this document.
+		
+		Used by `get_children` with behaviour defined by `_find_heirarchical`.
+		"""
+		
+		if __debug__:
+			log.debug("Finding children by materialized path: " + str(self.path), extra={'document': self})
+		
+		if not self.path:
+			return
+		
+		return self.__class__.path.re(r'^', escape(str(self.path)), r'\/[^\/]+$')
+	
+	@property
+	def descendants(self):
+		"""A query fragment selecting for the descendants of this document.
+		
+		Used by `get_descendants` with behaviour defined by `_find_heirarchical`.
+		"""
+		
+		return self.__class__.path.re(r'^', escape(str(self.path)), r'\/')
+	
+	# Active Collection Methods
+	
+	@classmethod
+	def get_nearest(cls, path, *args, **kw):
+		"""Find and return the deepest Asset matching the given path."""
+		
+		path = PurePosixPath(path)
+		absolute = path.is_absolute()
+		parents = (parent for parent in path.parents if absolute or parent.name)
+		kw.setdefault('sort', ('-path', ))
+		
+		return cls.find_one(*args, path__in=chain((path, ), parents), **kw)
+	
+	@classmethod
+	def find_nearest(cls, path, *args, **kw):
+		"""Find all nodes up to the deepest node matched by the given path.
+		
+		Conceptually the reverse of `get_nearest`.
+		"""
+		
+		path = PurePosixPath(path)
+		absolute = path.is_absolute()
+		parents = (parent for parent in path.parents if absolute or parent.name)
+		kw.setdefault('sort', ('-path', ))
+		
+		for doc in cls.find(*args, path__in=chain((path, ), parents), **kw):
+			yield cls.from_mongo(doc)
+	
+	# Active Document Methods
+	
+	def detach(self):
+		"""Detach this document from its tree, forming the root of a new tree containing this document and its children."""
+		
+		self = super(HPath, self).detach()
+		
+		if not self.path.root:
+			return self  # Already detached.
+		
+		Doc = self.__class__
+		collection = self.get_collection()
+		length = len(str(self.path.parent)) + 1
+		bulk = collection.initialize_unordered_bulk_op()
+		
+		bulk.find(Doc.id == self.id).update(U(Doc, path=self.slug))
+		
+		for descendant in self.find_descendants(projection=('id', 'path')):
+			bulk.find(Doc.id == descendant['_id']).update(U(Doc, path=descendant['path'][length:]))
+		
+		result = bulk.execute()
+		
+		self.path = self.slug  # Clean up to save needing to reload the record.
+		
+		return self
+	
+	def _attach(self, child, ops, project=()):
+		"""Attach the given child document (with any descendants) to this document.
+		
+		This is not an atomic operation unless the node has no descendents and no other heirarchical mix-ins.
+		"""
+		
+		assert self.path, "Path required for child attachment."
+		
+		project = {'id', 'path'}.union(project)  # We need the path field, if not present.
+		child, invalidated = super(HPath, self)._attach(child, ops, project)
+		
+		assert child.path, "Child must have addressable path, even if detached."
+		assert child.path.name, "Child must not be literal root element."
+		
+		# Step one, update the child itself. Speed matters on these, so we avoid using parametric helpers where
+		# reasonable to do so. Pro tip, re-mapping the back-end name of trait-provided fields is bad news bears.
+		# Matters more in the tight loop seen in step two, below.
+		
+		chop = len(str(child.path)) - len(child.path.name)
+		ops.find({'_id': child.id}).update_one({'$set': {'path': str(self.path / child.path.name)}})
+		child.path = self.path / child.path.name
+		
+		# Step two, find descendants of the child and update them. There might not be any, but why waste a round trip?
+		
+		for offspring in self.get_collection().find(self.descendents, project={'path': 1}):
+			path = str(self.path / offspring['path'][chop:])
+			ops.find({'_id': offspring['_id']}).update_one({'$set': {'path': path}})
+		
+		return self

--- a/marrow/mongo/core/trait/identified.py
+++ b/marrow/mongo/core/trait/identified.py
@@ -22,7 +22,7 @@ class Identified(Document):
 	id = ObjectId('_id', assign=True, write=False, repr=False)
 	
 	def __eq__(self, other):
-		"""Equality comparison between the IDs of the respective documents."""
+		"""Equality comparison between the identifiers of the respective documents."""
 		
 		if isinstance(other, Document):
 			return self.id == other.id
@@ -32,7 +32,4 @@ class Identified(Document):
 	def __ne__(self, other):
 		"""Inverse equality comparison between the backing store and other value."""
 		
-		if isinstance(other, Document):
-			return self.id != other.id
-		
-		return self.id != other
+		return not self == other

--- a/marrow/mongo/core/trait/queryable.py
+++ b/marrow/mongo/core/trait/queryable.py
@@ -45,6 +45,7 @@ class Queryable(Collection):
 			'maxTimeMs': 'max_time_ms',  # Common typo.
 			'noCursorTimeout': 'no_cursor_timeout',
 			'oplogReplay': 'oplog_replay',
+			'wait': 'await',  # XXX: 'await' will be reserved in 3.7+
 		}
 	
 	AGGREGATE_OPTIONS = UNIVERSAL_OPTIONS | {

--- a/marrow/mongo/core/trait/queryable.py
+++ b/marrow/mongo/core/trait/queryable.py
@@ -214,7 +214,7 @@ class Queryable(Collection):
 		"""
 		
 		if len(args) == 1 and not isinstance(args[0], Filter):
-			args = (cls.id == args[0], )
+			args = (getattr(cls, cls.__pk__) == args[0], )
 		
 		Doc, collection, query, options = cls._prepare_find(*args, **kw)
 		result = Doc.from_mongo(collection.find_one(query, **options))

--- a/marrow/mongo/query/query.py
+++ b/marrow/mongo/query/query.py
@@ -154,15 +154,20 @@ class Q(object):
 	def _op(self, operation, other, *allowed):
 		"""A basic operation operating on a single value."""
 		
+		f = self._field
+		
 		if self._combining:  # We are a field-compound query fragment, e.g. (Foo.bar & Foo.baz).
 			return reduce(self._combining,
-					(q._op(operation, other, *allowed) for q in self._field))  # pylint:disable=protected-access
+					(q._op(operation, other, *allowed) for q in f))  # pylint:disable=protected-access
 		
 		# Optimize this away in production; diagnosic aide.
-		if __debug__ and _complex_safety_check(self._field, {operation} & set(allowed)):  # pragma: no cover
+		if __debug__ and _complex_safety_check(f, {operation} & set(allowed)):  # pragma: no cover
 			raise NotImplementedError("{self!r} does not allow {op} comparison.".format(self=self, op=operation))
 		
-		return Filter({self._name: {operation: self._field.transformer.foreign(other, (self._field, self._document))}})
+		if other is not None:
+			other = f.transformer.foreign(other, (f, self._document))
+		
+		return Filter({self._name: {operation: other}})
 	
 	def _iop(self, operation, other, *allowed):
 		"""An iterative operation operating on multiple values.
@@ -170,17 +175,23 @@ class Q(object):
 		Consumes iterators to construct a concrete list at time of execution.
 		"""
 		
+		f = self._field
+		
 		if self._combining:  # We are a field-compound query fragment, e.g. (Foo.bar & Foo.baz).
 			return reduce(self._combining,
-					(q._iop(operation, other, *allowed) for q in self._field))  # pylint:disable=protected-access
+					(q._iop(operation, other, *allowed) for q in f))  # pylint:disable=protected-access
 		
 		# Optimize this away in production; diagnosic aide.
-		if __debug__ and _complex_safety_check(self._field, {operation} & set(allowed)):  # pragma: no cover
+		if __debug__ and _complex_safety_check(f, {operation} & set(allowed)):  # pragma: no cover
 			raise NotImplementedError("{self!r} does not allow {op} comparison.".format(
 					self=self, op=operation))
 		
+		def _t(o):
+			for value in o:
+				yield None if value is None else f.transformer.foreign(value, (f, self._document))
+		
 		other = other if len(other) > 1 else other[0]
-		values = [self._field.transformer.foreign(value, (self._field, self._document)) for value in other]
+		values = list(_t(other))
 		
 		return Filter({self._name: {operation: values}})
 	
@@ -213,14 +224,16 @@ class Q(object):
 		Documentation: https://docs.mongodb.org/manual/reference/operator/query/eq/#op._S_eq
 		"""
 		
+		f = self._field
+		
 		if self._combining:  # We are a field-compound query fragment, e.g. (Foo.bar & Foo.baz).
-			return reduce(self._combining, (q.__eq__(other) for q in self._field))
+			return reduce(self._combining, (q.__eq__(other) for q in f))
 		
 		# Optimize this away in production; diagnosic aide.
 		if __debug__ and _simple_safety_check(self._field, '$eq'):  # pragma: no cover
 			raise NotImplementedError("{self!r} does not allow $eq comparison.".format(self=self))
 		
-		return Filter({self._name: self._field.transformer.foreign(other, (self._field, self._document))})
+		return Filter({self._name: None if other is None else f.transformer.foreign(other, (f, self._document))})
 	
 	def __gt__(self, other):
 		"""Matches values that are greater than a specified value.
@@ -374,7 +387,7 @@ class Q(object):
 	def re(self, *parts):
 		"""Matches string values against a regular expression compiled of individual parts.
 		
-			Document.field.re(r'^', variable_part, r'\.')
+			Document.field.re(r'^', variable_part, r'.')
 		
 		Regex operator: {$regex: value}
 		Documentation: https://docs.mongodb.com/manual/reference/operator/query/regex/

--- a/marrow/mongo/util/__init__.py
+++ b/marrow/mongo/util/__init__.py
@@ -5,10 +5,16 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from operator import attrgetter
-from bson.tz_util import utc
 
 from marrow.schema.meta import ElementMeta
 from ...package.loader import load
+
+# Conditional dependencies.
+
+try:
+	from pytz import utc  # Richer, more capable implementation.
+except ImportError:
+	from bson.tz_util import utc  # Fallback on hard dependency.
 
 
 SENTINEL = object()  # Singleton value to detect unassigned values.

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,16 +11,13 @@ bdist-base = .packaging/dist
 
 [build]
 build-base = .packaging/build
+parallel = 3
 
 [install]
 optimize = 1
 
 [bdist]
 bdist-base = .packaging/dist
-dist-dir = .packaging/release
-
-[bdist_egg]
-bdist-dir = .packaging/dist
 dist-dir = .packaging/release
 
 [bdist_wheel]

--- a/setup.py
+++ b/setup.py
@@ -90,9 +90,10 @@ setup(
 	extras_require = dict(
 			decimal = ['pymongo>=3.4'],  # More modern version required for Decimal128 support.
 			development = tests_require + ['pre-commit'],  # Development-time dependencies.
-			scripting = ['javascripthon<1.0'],  # Allow map/reduce functions and "stored functions" to be Python.
-			logger = ['tzlocal'],  # Timezone support to store log times in UTC like a sane person.
+			logger = ['tzlocal>=1.4'],  # Timezone support to store log times in UTC like a sane person.
 			markdown = ['misaka', 'pygments'],  # Markdown text storage.
+			scripting = ['javascripthon<1.0'],  # Allow map/reduce functions and "stored functions" to be Python.
+			timezone = ['pytz', 'tzlocal>=1.4'],  # Support for timezones.
 		),
 	
 	tests_require = tests_require,

--- a/test/query/test_q.py
+++ b/test/query/test_q.py
@@ -128,8 +128,8 @@ class TestQueryable(object):  # TODO: Properly use pytest fixtures for this...
 		assert unicode(Sample.generic) == ~Sample.generic == 'generic'
 	
 	def test_operator_re(self):
-		result = Sample.field.re(r'^', 'foo', r'\.')
-		assert result.as_query == {'field_name': {'$regex': r'^foo\.'}}
+		result = Sample.field.re(r'^', 'foo', r'.')
+		assert result.as_query == {'field_name': {'$regex': r'^foo.'}}
 	
 	def test_operator_size(self):
 		result = Sample.array.size(10)

--- a/test/trait/test_queryable.py
+++ b/test/trait/test_queryable.py
@@ -51,22 +51,22 @@ class TestQueryableCore(object):
 			Sample._prepare_find(cursor_type=CursorType.TAILABLE, tail=True)
 		
 		with pytest.raises(TypeError):
-			Sample._prepare_find(cursor_type=CursorType.TAILABLE, await=True)
+			Sample._prepare_find(cursor_type=CursorType.TAILABLE, wait=True)
 		
 		with pytest.raises(TypeError):
-			Sample._prepare_find(cursor_type=CursorType.TAILABLE, tail=True, await=True)
+			Sample._prepare_find(cursor_type=CursorType.TAILABLE, tail=True, wait=True)
 	
 	def test_prepare_find_cursor_type_tail(self, Sample):
 		cls, collection, query, options = Sample._prepare_find(tail=True)
 		assert options['cursor_type'] == CursorType.TAILABLE_AWAIT
 	
 	def test_prepare_find_cursor_type_tail_not_await(self, Sample):
-		cls, collection, query, options = Sample._prepare_find(tail=True, await=False)
+		cls, collection, query, options = Sample._prepare_find(tail=True, wait=False)
 		assert options['cursor_type'] == CursorType.TAILABLE
 	
 	def test_prepare_find_cursor_type_await_conflict(self, Sample):
 		with pytest.raises(TypeError):
-			Sample._prepare_find(await=False)
+			Sample._prepare_find(wait=False)
 	
 	def test_prepare_find_max_time_modifier(self, Sample):
 		cls, collection, query, options = Sample._prepare_find(max_time_ms=1000)
@@ -114,7 +114,7 @@ class TestQueryableTrait(object):
 	def test_reload_all(self, Sample):
 		doc = Sample.find_one(integer=42)
 		assert doc.string == 'baz'
-		Sample.get_collection().update(Sample.id == doc, U(Sample, integer=1337, string="hoi"))
+		Sample.get_collection().update_one(Sample.id == doc, U(Sample, integer=1337, string="hoi"))
 		assert doc.string == 'baz'
 		doc.reload()
 		assert doc.string == 'hoi'
@@ -123,7 +123,7 @@ class TestQueryableTrait(object):
 	def test_reload_specific(self, Sample):
 		doc = Sample.find_one(integer=42)
 		assert doc.string == 'baz'
-		Sample.get_collection().update(Sample.id == doc, U(Sample, integer=1337, string="hoi"))
+		Sample.get_collection().update_one(Sample.id == doc, U(Sample, integer=1337, string="hoi"))
 		assert doc.string == 'baz'
 		doc.reload('string')
 		assert doc.string == 'hoi'

--- a/test/util/test_capped.py
+++ b/test/util/test_capped.py
@@ -55,27 +55,27 @@ _PRIORITY = (-2, -1, 0, 1, 2)
 
 
 def gen_log_entries(collection, count=1000):
-	collection.insert({'message': 'first'})  # To avoid immediate exit of the tail.ddddd
+	collection.insert_one({'message': 'first'})  # To avoid immediate exit of the tail.ddddd
 	
 	for i in range(count-2):
 		sleep(3.0/count)  # If we go too fast, the test might not be able to keep up.
-		collection.insert({'message': 'test #' + str(i) + ' of ' + str(count), 'priority': choice(_PRIORITY)})
+		collection.insert_one({'message': 'test #' + str(i) + ' of ' + str(count), 'priority': choice(_PRIORITY)})
 	
-	collection.insert({'message': 'last'})
+	collection.insert_one({'message': 'last'})
 
 
 class TestCappedQueries(object):
 	def test_single(self, capped):
 		assert capped.count() == 0
-		result = capped.insert({'message': 'first'})
+		result = capped.insert_one({'message': 'first'})
 		assert capped.count() == 1
 		
 		first = next(tail(capped))
 		assert first['message'] == 'first'
-		assert first['_id'] == result
+		assert first['_id'] == result.inserted_id
 	
 	def test_basic_timeout(self, capped):
-		capped.insert({'message': 'first'})
+		capped.insert_one({'message': 'first'})
 		
 		start = time()
 		
@@ -96,7 +96,7 @@ class TestCappedQueries(object):
 	def test_patch(self, capped):
 		_patch()
 		
-		capped.insert({})
+		capped.insert_one({})
 		
 		assert len(list(capped.tail(timeout=0.25))) == 1
 	


### PR DESCRIPTION
* [ ] Heirarchical base trait.
* [ ] HPath path-based heirarchical trait.
* [ ] HParent adjacency list-based heirarchical trait.

Additional substantial changes:

* [x] **Fix:** Filter comparisons involving `None` values attempting to utilize typecasting.
* [ ] **Add:** Date field timezone conversion and naïve date handling.

Additionally:

* Minor optimizations for CPython.
* More and better documentation.
* Cleanup of dead imports, code, testing, deprecation warnings, and Python egg legacy.
* Updated dependencies, and preferential use of `pytz.utc` over `bson.tz_util.utc` if available.
* In the `Queryable` (beta) trait, `await` is becoming a reserved word in Python 3.7 so use `wait` instead.